### PR TITLE
Correcting the name of the 8th month in Indonesian from `Augustus` to `Agustus`

### DIFF
--- a/lib/locales/id.yml
+++ b/lib/locales/id.yml
@@ -40,7 +40,7 @@ id:
     - Mei
     - Juni
     - Juli
-    - Augustus
+    - Agustus
     - September
     - Oktober
     - November


### PR DESCRIPTION


Ref: https://kbbi.kemdikbud.go.id/entri/agustus